### PR TITLE
Fixed Bug for Querying Summer 10-week courses

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,13 +120,13 @@ function getCodedTerm(term) {
         actualTerm = term.slice(0, 4) + '-03';
     } else if (term.includes('spring')) {
         actualTerm = term.slice(0, 4) + '-14';
+    } else if (term.includes('summer10wk')) {
+        actualTerm = term.slice(0, 4) + '-39';
     } else if (term.includes('summer1')) {
         actualTerm = term.slice(0, 4) + '-25';
     } else if (term.includes('summer2')) {
         actualTerm = term.slice(0, 4) + '-76';
-    } else if (term.includes('summer10wk')) {
-        actualTerm = term.slice(0, 4) + '-39';
-    }
+    } 
 
     return actualTerm
 }


### PR DESCRIPTION
When querying for Summer 10wk courses, it would use the coded term for summer1. In the if `summer10wk` includes `summer1` so that check would pass and it would create an incorrect query. 

It is now fixed so that `summer10wk` is checked before `summer1`.